### PR TITLE
support passing a specific number of executors to the swarm client

### DIFF
--- a/cmd.sh
+++ b/cmd.sh
@@ -10,6 +10,9 @@ fi
 if [ ! -z "$JENKINS_PASSWORD" ]; then
   PARAMS="$PARAMS -password $JENKINS_PASSWORD"
 fi
+if [ ! -z "$SLAVE_EXECUTORS" ]; then
+  PARAMS="$PARAMS -executors $SLAVE_EXECUTORS"
+fi
 if [ ! -z "$JENKINS_MASTER" ]; then
   PARAMS="$PARAMS -master $JENKINS_MASTER"
 else


### PR DESCRIPTION
Following https://wiki.jenkins-ci.org/display/JENKINS/Swarm+Plugin I added support for specifying the number of concurrent build executors for each slave.
